### PR TITLE
Fix/2953 protectedfields filter columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Details:
 
 > ### “If you are curious to see what's next!”
 
+### Bug Fixes
+
+- Fixed issue where Protected Fields would allow selecting columns that do not exist in the current class, causing silent save failures (#2953). Now, only columns belonging to the active class are displayed in the selector.
+
 These releases contain the latest development changes, but you should be prepared for anything, including sudden breaking changes or code refactoring. Use this branch to contribute to the project and open pull requests.
 
 Details:

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -18,6 +18,7 @@ import LoginDialog from 'dashboard/Data/Browser/LoginDialog.react';
 import SecureFieldsDialog from 'dashboard/Data/Browser/SecureFieldsDialog.react';
 import SecurityDialog from 'dashboard/Data/Browser/SecurityDialog.react';
 import prettyNumber from 'lib/prettyNumber';
+import { buildClassSchemaData } from 'lib/schemaUtils';
 import React, { useRef } from 'react';
 
 const BrowserToolbar = ({
@@ -214,53 +215,12 @@ const BrowserToolbar = ({
     onClick = null;
   }
 
-  const columns = {};
-  const userPointers = [];
-  const schemaSimplifiedData = {};
-  const classSchema = schema.data.get('classes').get(classNameForEditors);
-  if (classSchema) {
-    classSchema.forEach(({ type, targetClass }, col) => {
-      schemaSimplifiedData[col] = {
-        type,
-        targetClass,
-      };
-
-      columns[col] = { type, targetClass };
-
-      if (col === 'objectId' || (isUnique && col !== uniqueField)) {
-        return;
-      }
-      if ((type === 'Pointer' && targetClass === '_User') || type === 'Array') {
-        userPointers.push(col);
-      }
-    });
-  }
-
-  allClasses.forEach(className => {
-    const classSchema = schema.data.get('classes').get(className);
-
-    if (classSchema) {
-      schemaSimplifiedData[className] = {};
-
-      classSchema.forEach(({ type, targetClass }, col) => {
-        schemaSimplifiedData[className][col] = {
-          type,
-          targetClass,
-        };
-
-        columns[col] = { type, targetClass };
-
-        if (col === 'objectId' || (isUnique && col !== uniqueField)) {
-          return;
-        }
-        if ((type === 'Pointer' && targetClass === '_User') || type === 'Array') {
-          userPointers.push(col);
-        }
-      });
-    } else {
-      console.log(`Class ${className} not found in schema.`);
-    }
-  });
+  const { columns, userPointers, schemaSimplifiedData } = buildClassSchemaData(
+    schema,
+    classNameForEditors,
+    isUnique,
+    uniqueField
+  );
 
   const clpDialogRef = useRef(null);
   const protectedDialogRef = useRef(null);

--- a/src/lib/schemaUtils.js
+++ b/src/lib/schemaUtils.js
@@ -1,0 +1,26 @@
+export function buildClassSchemaData(schema, className, isUnique, uniqueField) {
+    const columns = {};
+    const userPointers = [];
+    const schemaSimplifiedData = {};
+
+    // Get the schema for the specified class
+    const classSchema = schema.data.get('classes')?.get(className);
+    if (classSchema) {
+        schemaSimplifiedData[className] = {};
+        classSchema.forEach(({ type, targetClass }, col) => {
+            // Populate simplified schema and column metadata
+            schemaSimplifiedData[className][col] = { type, targetClass };
+            columns[col] = { type, targetClass };
+
+            // Skip objectId or other columns when uniqueness is enforced
+            if (col === 'objectId' || (isUnique && col !== uniqueField)) return;
+
+            // Track user pointers and array columns separately
+            if ((type === 'Pointer' && targetClass === '_User') || type === 'Array') {
+                userPointers.push(col);
+            }
+        });
+    }
+
+    return { columns, userPointers, schemaSimplifiedData };
+}

--- a/src/lib/tests/schemaUtils.test.js
+++ b/src/lib/tests/schemaUtils.test.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+const { buildClassSchemaData } = require('../../lib/schemaUtils');
+
+describe('buildClassSchemaData', () => {
+  it('should return empty objects when class does not exist', () => {
+    const schema = { data: new Map([['classes', new Map()]]) };
+    const result = buildClassSchemaData(schema, 'NonExistentClass', false, null);
+
+    expect(result.columns).toEqual({});
+    expect(result.userPointers).toEqual([]);
+    expect(result.schemaSimplifiedData).toEqual({});
+  });
+
+it('should return columns and schemaSimplifiedData for a normal class', () => {
+    const schema = {
+      data: new Map([
+        ['classes', new Map([
+          ['TestClass', new Map([
+            ['name', { type: 'String' }],
+            ['age', { type: 'Number' }],
+            ['objectId', { type: 'String' }]
+          ])]
+        ])]
+      ])
+    };
+
+    const result = buildClassSchemaData(schema, 'TestClass', false, null);
+
+    expect(result.columns).toEqual({
+      name: { type: 'String' },
+      age: { type: 'Number' },
+      objectId: { type: 'String' }
+    });
+    expect(result.userPointers).toEqual([]);
+    expect(result.schemaSimplifiedData).toEqual({
+      TestClass: {
+        name: { type: 'String' },
+        age: { type: 'Number' },
+        objectId: { type: 'String' }
+      }
+    });
+  });
+
+  it('should identify _User pointers and Array columns', () => {
+    const schema = {
+      data: new Map([
+        ['classes', new Map([
+          ['TestClass', new Map([
+            ['owner', { type: 'Pointer', targetClass: '_User' }],
+            ['tags', { type: 'Array' }],
+            ['objectId', { type: 'String' }]
+          ])]
+        ])]
+      ])
+    };
+
+    const result = buildClassSchemaData(schema, 'TestClass', false, null);
+
+    expect(result.userPointers).toEqual(['owner', 'tags']);
+  });
+});


### PR DESCRIPTION
**Issue**

Fix: Filter non-existent columns in Protected Fields picker (#2953)

**Problema**

Atualmente, ao editar `Protected Fields` no Parse Dashboard, o seletor (`picker`) exibe todas as colunas de todas as classes sem filtro, em ordem aparentemente aleatória.

Quando um usuário seleciona uma coluna que não existe na tabela atual e tenta salvar, ocorre falha silenciosa:

``` 
  Uncaught TypeError: can't access property "toggleActive", r.refScrollHint.current is null
  Error: Field 'qweasd' in protectedFields:* does not exist
```

Ou seja, o Dashboard permite selecionar colunas irrelevantes e o objeto não é salvo corretamente.

**Abordagem e Decisões de Design**

* Criei a função `buildClassSchemaData`, que:

  1. Recebe o `schema` da classe específica.

  2. Retorna apenas as colunas existentes da classe atual, filtrando campos irrelevantes.

  3. Garante que o seletor de Protected Fields mostre apenas colunas válidas.

* Substituí o código anterior no `BrowserToolbar` pela chamada à nova função `buildClassSchemaData`.


Exemplo do método:

```javascript
export function buildClassSchemaData(schema, className, isUnique, uniqueField) {
    const columns = {};
    const userPointers = [];
    const schemaSimplifiedData = {};

    const classSchema = schema.data.get('classes')?.get(className);

    if (classSchema) {
        schemaSimplifiedData[className] = {};
        classSchema.forEach(({ type, targetClass }, col) => {
            schemaSimplifiedData[className][col] = { type, targetClass };
            columns[col] = { type, targetClass };

            if (col === 'objectId' || (isUnique && col !== uniqueField)) return;

            if ((type === 'Pointer' && targetClass === '_User') || type === 'Array') {
                userPointers.push(col);
            }
        });
    }

    return { columns, userPointers, schemaSimplifiedData };
}
```

**Evidências**

* ✅ Antes: o `picker` de `Protected Fields` permitia selecionar colunas inexistentes e falhava silenciosamente ao salvar.

[protected_fields_error.webm](https://github.com/user-attachments/assets/5c29abf7-0cd9-4ace-a08e-3e61a92882fd)

* ✅ Depois: o seletor exibe apenas colunas válidas da classe atual, e a operação de salvar funciona corretamente.

[protected_fields_ok.webm](https://github.com/user-attachments/assets/d0ae86b8-15e7-4c68-8f68-f6c66c4e57eb)

**Testes Automatizados**

Adicionei testes unitários para garantir a correção e prevenir regressões:

* Classe inexistente retorna objetos e arrays vazios.

* Classe normal retorna columns e schemaSimplifiedData corretamente, incluindo objectId.

* Identificação de colunas do tipo Pointer para _User e colunas do tipo Array, populando userPointers corretamente.

Exemplo:

```javascript
it('should identify _User pointers and Array columns', () => {
  const schema = {
    data: new Map([
      ['classes', new Map([
        ['TestClass', new Map([
          ['owner', { type: 'Pointer', targetClass: '_User' }],
          ['tags', { type: 'Array' }],
          ['objectId', { type: 'String' }]
        ])]
      ])]
    ])
  };

  const result = buildClassSchemaData(schema, 'TestClass', false, null);
  expect(result.userPointers).toEqual(['owner', 'tags']);
});
```

**Checklist**

- [x] Corrigido bug da issue #2953.

- [x] Adicionados testes unitários para a correção.

- [x] Evidência em vídeo mostrando antes e depois.

- [x] CI passando com sucesso.
