### PR TITLE
Fix/2600 auth data filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Details:
 
 > ### “If you are curious to see what's next!”
 
+### Bug Fixes
+
+- Fixed issue where filtering with authData "key does not exist" would show incorrect results (#2600). The filter now correctly ignores records that contain the authData key, showing only those that truly do not have it.
+
 These releases contain the latest development changes, but you should be prepared for anything, including sudden breaking changes or code refactoring. Use this branch to contribute to the project and open pull requests.
 
 Details:

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -7,7 +7,7 @@
  */
 import Parse from 'parse';
 
-export default async function queryFromFilters(className, filters) {
+async function queryFromFilters(className, filters) {
   let primaryQuery;
   const querieslist = [];
   if (typeof className === 'string') {
@@ -217,3 +217,6 @@ function addConstraint(query, filter) {
   }
   return query;
 }
+
+export default queryFromFilters;
+export { mapAuthDataField };

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -109,7 +109,26 @@ function isPointer(value) {
   );
 }
 
+// Maps Parse authData fields to the internal _auth_data_<provider> format.
+function mapAuthDataField(field, compareTo) {
+  if (!field) {return field}; // Return if no field
+
+  const match = field.match(/^authData\.(.+)$/);
+  if (match) {
+    return `_auth_data_${match[1]}`; // Convert authData.<provider> to _auth_data_<provider>
+  }
+
+  if (field === 'authData' && compareTo) {
+    return `_auth_data_${compareTo}`; // Use compareTo as provider
+  }
+
+  return field;
+}
+
 function addConstraint(query, filter) {
+  const field = mapAuthDataField(filter.get('field'), filter.get('compareTo'));
+  const compareTo = filter.get('compareTo');
+
   switch (filter.get('constraint')) {
     case 'exists':
       query.exists(filter.get('field'));
@@ -138,8 +157,8 @@ function addConstraint(query, filter) {
       query.greaterThanOrEqualTo(filter.get('field'), filter.get('compareTo'));
       break;
     case 'starts':
-      const field = filter.get('field');
-      const compareTo = filter.get('compareTo');
+      // const field = filter.get('field');
+      // const compareTo = filter.get('compareTo');
       if (isPointer(compareTo)) {
         const pointerQuery = new Parse.Query(compareTo.className);
         pointerQuery.startsWith('objectId', compareTo.objectId);
@@ -172,10 +191,10 @@ function addConstraint(query, filter) {
       query.matches(filter.get('field'), filter.get('compareTo'), 'i');
       break;
     case 'keyExists':
-      query.exists(filter.get('field') + '.' + filter.get('compareTo'));
+      query.exists(field);
       break;
     case 'keyDne':
-      query.doesNotExist(filter.get('field') + '.' + filter.get('compareTo'));
+      query.doesNotExist(field);
       break;
     case 'keyEq':
       addQueryConstraintFromObject(query, filter, 'equalTo');

--- a/src/lib/tests/queryFromFilters.test.js
+++ b/src/lib/tests/queryFromFilters.test.js
@@ -1,0 +1,23 @@
+const { mapAuthDataField } = require('../../lib/queryFromFilters');
+
+describe('mapAuthDataField', () => {
+  it('should return the same field if no field is provided', () => {
+    expect(mapAuthDataField(null)).toBeNull();
+    expect(mapAuthDataField(undefined)).toBeUndefined();
+  });
+
+  it('should map authData.<provider> to _auth_data_<provider>', () => {
+    expect(mapAuthDataField('authData.anonymous')).toBe('_auth_data_anonymous');
+    expect(mapAuthDataField('authData.facebook')).toBe('_auth_data_facebook');
+  });
+
+  it('should map authData with compareTo as provider', () => {
+    expect(mapAuthDataField('authData', 'google')).toBe('_auth_data_google');
+    expect(mapAuthDataField('authData', 'customProvider')).toBe('_auth_data_customProvider');
+  });
+
+  it('should return the field unchanged if it does not match authData pattern', () => {
+    expect(mapAuthDataField('username')).toBe('username');
+    expect(mapAuthDataField('email')).toBe('email');
+  });
+});


### PR DESCRIPTION
**Issue**

Fix: Filter with authData "key does not exist" shows incorrect results (#2600)

**Problema**

Atualmente, ao filtrar no **Parse Dashboard** por campos `authData` usando a condição key does not exist ou key exits, os resultados exibem registros incorretos.

Por exemplo, ao filtrar authData para o provider anonymous:

* ✅ Esperado: apenas registros sem a chave anonymous no authData.

* ❌ Atual: registros com authData.anonymous também aparecem, mostrando dados incorretos.

Esse comportamento é causado pois no banco de dados o authData é salvo como `_auth_data_<provider>` e o filtro não transforma corretamente o campo `authData.<provider>` para o formato interno do banco `_auth_data_<provider>`.

**Abordagem e Decisões de Design**

* Criei a função `mapAuthDataField`, que mapeia campos `authData` para `_auth_data_<provider>`:

  1. Se o campo já vier como `authData.<provider>,` converte para `_auth_data_<provider>`.

  2. Se o campo for `authData` e o `compareTo` indicar o provider, também converte para `_auth_data_<provider>`.

  3. Campos que não seguem esse padrão permanecem inalterados.

Exemplo do método:

```javascript
function mapAuthDataField(field, compareTo) {
  if (!field) {return field};

  const match = field.match(/^authData\.(.+)$/);
  if (match) {
    return `_auth_data_${match[1]}`;
  }

  if (field === 'authData' && compareTo) {
    return `_auth_data_${compareTo}`;
  }

  return field;
}
```

* Integrei `mapAuthDataField` no processo de construção das queries, garantindo que filtros `keyDne` e `keyExists` referentes a authData funcionem corretamente.

**Evidências**

* ✅ Antes: filtro `"key does not exist"` e `"key exists"` retornavam registros incorretos.

[authData_error.webm](https://github.com/user-attachments/assets/4258c5ce-698c-4159-af13-3e66635a5f62)

* ✅ Depois: apenas os registros que correspondem ao `provider` correto são retornados, tanto para `"key exists"` quanto para `"key does not exist"`.

[authData_ok.webm](https://github.com/user-attachments/assets/4eeff607-577b-4ff7-b149-1784a58fa604)

**Testes Automatizados**

Adicionei testes unitários para garantir a correção e prevenir regressões:

* Campo `null` ou `undefined` retorna igual.

* Campo `authData.<provider>` é convertido corretamente para `_auth_data_<provider>`.

* Campo `authData` com `compareTo` também é convertido.

* Campos fora do padrão permanecem inalterados.

Exemplo:

```javascript
it('should map authData.<provider> to _auth_data_<provider>', () => {
  expect(mapAuthDataField('authData.anonymous')).toBe('_auth_data_anonymous');
  expect(mapAuthDataField('authData.facebook')).toBe('_auth_data_facebook');
});
```

**Checklist**

- [x] Corrigido bug da issue #2600.

- [x] Adicionados testes unitários para `mapAuthDataField`.

- [x] Vídeo demonstrando o comportamento antes e depois.

- [x] CI passando com sucesso.
